### PR TITLE
Device model and brand + Remove GenServer dependency.

### DIFF
--- a/lib/ua_parser.ex
+++ b/lib/ua_parser.ex
@@ -1,23 +1,11 @@
 defmodule UAParser do
   @moduledoc """
-  A fast User Agent parser with a simple API.
+  A not so fast User Agent parser with a widely used API.
   """
 
   use Application
 
   alias UAParser.{Parser, Storage}
-
-  @doc false
-  def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
-    children = [
-      worker(Storage, []),
-    ]
-
-    opts = [strategy: :one_for_one, name: UAParser.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
 
   @doc """
   Parse a user-agent string into structs

--- a/lib/ua_parser/device.ex
+++ b/lib/ua_parser/device.ex
@@ -14,7 +14,7 @@ defmodule UAParser.Device do
     iex> to_string(device)
     "Other"
   """
-  defstruct [:family]
+  defstruct [:family, :brand, :model]
 end
 
 defimpl String.Chars, for: UAParser.Device do

--- a/lib/ua_parser/parser.ex
+++ b/lib/ua_parser/parser.ex
@@ -26,7 +26,7 @@ defmodule UAParser.Parser do
   defp match(group, string) do
     match =
       group
-      |> Keyword.fetch!(:regex)
+      |> Map.fetch!(:regex)
       |> Regex.run(string)
 
     {group, match}
@@ -54,7 +54,7 @@ defmodule UAParser.Parser do
     groups
     |> Enum.find(fn(group) ->
       group
-      |> Keyword.fetch!(:regex)
+      |> Map.fetch!(:regex)
       |> Regex.match?(string)
     end)
     |> match(string)

--- a/lib/ua_parser/parsers/base.ex
+++ b/lib/ua_parser/parsers/base.ex
@@ -14,7 +14,7 @@ defmodule UAParser.Parsers.Base do
       def parse({group, match}) do
         family =
           group
-          |> Keyword.get(unquote(family_key))
+          |> Map.get(unquote(family_key))
           |> UAParser.Parsers.Base.replace(1, match)
 
         match   = Enum.slice(match, 1, 4)

--- a/lib/ua_parser/parsers/device.ex
+++ b/lib/ua_parser/parsers/device.ex
@@ -8,18 +8,20 @@ defmodule UAParser.Parsers.Device do
 
   import Base
   @behaviour Base
-
   def parse(nil), do: %Device{}
   def parse({group, match}) do
-    family = Keyword.get(group, :device_replacement)
-
-    family =
+    [family: :device_replacement, brand: :brand_replacement, model: :model_replacement ]
+    |> do_replacement({group,match}, %Device{})
+  end
+  def do_replacement([], _, device), do: device
+  def do_replacement([{key,replacement}| replacements],{group,match}, device) do
+    replace = Map.get(group, replacement)
+    replace =
       match
       |> Enum.with_index
-      |> Enum.reduce(family, fn({_, index}, acc) ->
+      |> Enum.reduce(replace, fn({_, index}, acc) ->
         replace(acc, index, match)
       end)
-
-    %Device{family: family}
+    do_replacement(replacements, {group,match}, Map.put(device,key,replace))
   end
 end

--- a/lib/ua_parser/parsers/version.ex
+++ b/lib/ua_parser/parsers/version.ex
@@ -15,7 +15,7 @@ defmodule UAParser.Parsers.Version do
     |> Enum.with_index
     |> Enum.map(fn({key, index}) ->
       group
-      |> Keyword.get(key)
+      |> Map.get(key)
       |> replace(index + 1, match)
     end)
     |> version

--- a/lib/ua_parser/processor.ex
+++ b/lib/ua_parser/processor.ex
@@ -29,30 +29,31 @@ defmodule UAParser.Processor do
   defp compile_group(group) do
     pattern =
       group
-      |> Keyword.fetch!(:regex)
+      |> Map.fetch!(:regex)
       |> Regex.compile!
 
-    Keyword.put(group, :regex, pattern)
+    Map.put(group, :regex, pattern)
   end
 
   defp compile_groups(groups), do: Enum.map(groups, &compile_group/1)
 
   defp convert([]), do: []
   defp convert([head|tail]) do
-    result = Enum.map(head, &to_keyword/1)
+    result = to_atoms(head)
     [result|convert(tail)]
   end
 
-  defp extract([document|_]) do
-    [{'user_agent_parsers', user_agents}, {'os_parsers', os}, {'device_parsers', devices}] = document
+  defp extract([document]) do
+
+    %{"user_agent_parsers"=>user_agents, "os_parsers"=> os, "device_parsers"=>devices} = document
 
     [user_agents, os, devices]
   end
 
-  defp to_keyword([]), do: []
-  defp to_keyword([{key, value}|tails]) do
-    keyword = {atom_key(key), String.Chars.to_string(value)}
-    [keyword | to_keyword(tails)]
+  defp to_atoms([]), do: []
+  defp to_atoms([head|tails]) do
+
+    [Enum.map(head, fn {k,v}-> {String.to_atom(k),v} end)|> Enum.into(%{}) | to_atoms(tails)]
   end
 
   defp to_tuple(values, tuple \\ {})

--- a/lib/ua_parser/storage.ex
+++ b/lib/ua_parser/storage.ex
@@ -1,46 +1,16 @@
 defmodule UAParser.Storage do
   @moduledoc """
-  Storage of User-Agent regular expressions.
+  Compile time loads regex data. Unfortunatley would require a restart for any pattern update
   """
 
-  use GenServer
-
-  alias __MODULE__, as: Storage
   alias UAParser.Processor
+  {:ok,doc} = (:code.priv_dir(:ua_parser) ++ '/patterns.yml')
+      |> to_string
+      |> Yomel.decode_file
+  data = Processor.process(doc)
+  @data data
 
-  @doc """
-  Start our GenServer.
-  """
-  def start_link(opts \\ []) do
-    GenServer.start_link(Storage, opts, name: Storage)
-  end
+  def list, do: @data
 
-  @doc """
-  Initialize storage
-  """
-  def init(opts), do: load_patterns(opts)
 
-  @doc """
-  Look for a matching User-Agent
-  """
-  def handle_call(:list, _from, opts),
-    do: {:reply, opts[:data], opts}
-
-  @doc """
-  """
-  def list, do: GenServer.call(Storage, :list)
-
-  defp load_patterns(opts) do
-    data =
-      :ua_parser
-      |> Application.get_env(:patterns)
-      |> :yamerl_constr.file
-      |> Processor.process
-
-    opts =
-      opts
-      |> Keyword.put(:data, data)
-
-    {:ok, opts}
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -18,15 +18,13 @@ defmodule UAParser.Mixfile do
 
   def application do
     [
-      applications: [:logger, :yamerl],
-      env: UAParser.Mixfile.env(),
-      mod: {UAParser, []},
+      applications: [:logger, :yomel]
     ]
   end
 
   defp deps do
     [
-      {:yamerl, "~> 0.4.0"},
+      {:yomel, "~> 0.5.0"},
       {:credo, "~> 0.5", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: :dev},
     ]
@@ -41,20 +39,5 @@ defmodule UAParser.Mixfile do
     ]
   end
 
-  def env do
-    [
-      patterns: get_patterns_filename,
-    ]
-  end
 
-  @spec get_patterns_filename() :: String.t
-  def get_patterns_filename do
-    priv_path =
-      :ua_parser
-      |> :code.priv_dir()
-      |> IO.chardata_to_string()
-
-    default_path = priv_path <> "/patterns.yml"
-    Application.get_env(:ua_parser, :patterns, default_path)
-  end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,5 @@
   "credo": {:hex, :credo, "0.5.3", "0c405b36e7651245a8ed63c09e2d52c2e2b89b6d02b1570c4d611e0fcbecf4a2", [:mix], [{:bunt, "~> 0.1.6", [hex: :bunt, optional: false]}]},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.4", "a0a79a6896075814f4bc6802b74ccbed6549f47cc5ab34c71eaee2303170b8ef", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "yamerl": {:hex, :yamerl, "0.4.0", "ae215b1242810a9bc07716b88062f1bfe06f6bc7cf68372091f630baa536df79", [:rebar3], []}}
+  "yamerl": {:hex, :yamerl, "0.4.0", "ae215b1242810a9bc07716b88062f1bfe06f6bc7cf68372091f630baa536df79", [:rebar3], []},
+  "yomel": {:hex, :yomel, "0.5.0", "c5a42d1818deda3f85ae14b1f01f6ece22b9ed8e8087012359fc04b59d85f621", [:make, :mix], []}}

--- a/priv/patterns.yml
+++ b/priv/patterns.yml
@@ -35,7 +35,7 @@ user_agent_parsers:
     family_replacement: 'MSIECrawler'
 
   # Downloader ...
-  - regex: '(Google-HTTP-Java-Client|Apache-HttpClient|http%20client|Python-urllib|HttpMonitor|TLSProber|WinHTTP|JNLP)(?:[ /](\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
+  - regex: '(Google-HTTP-Java-Client|Apache-HttpClient|http%20client|Python-urllib|HttpMonitor|TLSProber|WinHTTP|JNLP|okhttp)(?:[ /](\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
 
   # Bots
   - regex: '(1470\.net crawler|50\.nu|8bo Crawler Bot|Aboundex|Accoona-[A-z]+-Agent|AdsBot-Google(?:-[a-z]+)?|altavista|AppEngine-Google|archive.*?\.org_bot|archiver|Ask Jeeves|[Bb]ai[Dd]u[Ss]pider(?:-[A-Za-z]+)*|bingbot|BingPreview|blitzbot|BlogBridge|BoardReader(?: [A-Za-z]+)*|boitho.com-dc|BotSeer|\b\w*favicon\w*\b|\bYeti(?:-[a-z]+)?|Catchpoint bot|[Cc]harlotte|Checklinks|clumboot|Comodo HTTP\(S\) Crawler|Comodo-Webinspector-Crawler|ConveraCrawler|CRAWL-E|CrawlConvera|Daumoa(?:-feedfetcher)?|Feed Seeker Bot|findlinks|Flamingo_SearchEngine|FollowSite Bot|furlbot|Genieo|gigabot|GomezAgent|gonzo1|(?:[a-zA-Z]+-)?Googlebot(?:-[a-zA-Z]+)?|Google SketchUp|grub-client|gsa-crawler|heritrix|HiddenMarket|holmes|HooWWWer|htdig|ia_archiver|ICC-Crawler|Icarus6j|ichiro(?:/mobile)?|IconSurf|IlTrovatore(?:-Setaccio)?|InfuzApp|Innovazion Crawler|InternetArchive|IP2[a-z]+Bot|jbot\b|KaloogaBot|Kraken|Kurzor|larbin|LEIA|LesnikBot|Linguee Bot|LinkAider|LinkedInBot|Lite Bot|Llaut|lycos|Mail\.RU_Bot|masidani_bot|Mediapartners-Google|Microsoft .*? Bot|mogimogi|mozDex|MJ12bot|msnbot(?:-media *)?|msrbot|netresearch|Netvibes|NewsGator[^/]*|^NING|Nutch[^/]*|Nymesis|ObjectsSearch|Orbiter|OOZBOT|PagePeeker|PagesInventory|PaxleFramework|Peeplo Screenshot Bot|PlantyNet_WebRobot|Pompos|Read%20Later|Reaper|RedCarpet|Retreiver|Riddler|Rival IQ|scooter|Scrapy|Scrubby|searchsight|seekbot|semanticdiscovery|Simpy|SimplePie|SEOstats|SimpleRSS|SiteCon|Slackbot-LinkExpanding|Slack-ImgProxy|Slurp|snappy|Speedy Spider|Squrl Java|TheUsefulbot|ThumbShotsBot|Thumbshots\.ru|TwitterBot|URL2PNG|Vagabondo|VoilaBot|^vortex|Votay bot|^voyager|WASALive.Bot|Web-sniffer|WebThumb|WeSEE:[A-z]+|WhatWeb|WIRE|WordPress|Wotbox|www\.almaden\.ibm\.com|Xenu(?:.s)? Link Sleuth|Xerka [A-z]+Bot|yacy(?:bot)?|Yahoo[a-z]*Seeker|Yahoo! Slurp|Yandex\w+|YodaoBot(?:-[A-z]+)?|YottaaMonitor|Yowedo|^Zao|^Zao-Crawler|ZeBot_www\.ze\.bz|ZooShot|ZyBorg)(?:[ /]v?(\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
@@ -160,7 +160,7 @@ user_agent_parsers:
 
   # Lightning (for Thunderbird)
   # http://www.mozilla.org/projects/calendar/lightning/
-  - regex: '(Lightning)/(\d+)\.(\d+)\.?((?:[ab]?\d+[a-z]*)|(?:\d*))'
+  - regex: 'Gecko/\d+ (Lightning)/(\d+)\.(\d+)\.?((?:[ab]?\d+[a-z]*)|(?:\d*))'
 
   # Swiftfox
   - regex: '(Firefox)/(\d+)\.(\d+)\.(\d+(?:pre)?) \(Swiftfox\)'
@@ -276,12 +276,16 @@ user_agent_parsers:
   # AOL Browser (IE-based)
   - regex: '(AOL) (\d+)\.(\d+); AOLBuild (\d+)'
 
+  # MxBrowser is Maxthon
+  - regex: '(MxBrowser)/(\d+)\.(\d+)(?:\.(\d+))?'
+    family_replacement: 'Maxthon'
+
   #### END SPECIAL CASES TOP ####
 
   #### MAIN CASES - this catches > 50% of all browsers ####
 
   # Browser/major_version.minor_version.beta_version
-  - regex: '\b(MobileIron|Crosswalk|AdobeAIR|FireWeb|Jasmine|ANTGalio|Midori|Fresco|Lobo|PaleMoon|Maxthon|Lynx|OmniWeb|Dillo|Camino|Demeter|Fluid|Fennec|Epiphany|Shiira|Sunrise|Spotify|Flock|Netscape|Lunascape|WebPilot|NetFront|Netfront|Konqueror|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|Opera Mini|iCab|NetNewsWire|ThunderBrowse|Iris|UP\.Browser|Bunjalloo|Google Earth|Raven for Mac|Openwave|MacOutlook)/(\d+)\.(\d+)\.(\d+)'
+  - regex: '\b(MobileIron|Crosswalk|FireWeb|Jasmine|ANTGalio|Midori|Fresco|Lobo|PaleMoon|Maxthon|Lynx|OmniWeb|Dillo|Camino|Demeter|Fluid|Fennec|Epiphany|Shiira|Sunrise|Spotify|Flock|Netscape|Lunascape|WebPilot|NetFront|Netfront|Konqueror|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|Opera Mini|iCab|NetNewsWire|ThunderBrowse|Iris|UP\.Browser|Bunjalloo|Google Earth|Raven for Mac|Openwave|MacOutlook|Electron)/(\d+)\.(\d+)\.(\d+)'
 
   # Outlook 2007
   - regex: 'Microsoft Office Outlook 12\.\d+\.\d+|MSOffice 12'
@@ -336,18 +340,19 @@ user_agent_parsers:
   - regex: '(brave)/(\d+)\.(\d+)\.(\d+) Chrome'
     family_replacement: 'Brave'
 
-  # Chrome/Chromium/major_version.minor_version.beta_version
-  - regex: '(Chromium|Chrome)/(\d+)\.(\d+)\.(\d+)'
+  # Iron Browser ~since version 50
+  - regex: '(Chrome)/(\d+)\.(\d+)\.(\d+)[\d.]* Iron[^/]'
+    family_replacement: 'Iron'
 
   # Dolphin Browser
   # @ref: http://www.dolphin.com
   - regex: '\b(Dolphin)(?: |HDCN/|/INT\-)(\d+)\.(\d+)\.?(\d+)?'
 
   # Browser/major_version.minor_version
-  - regex: '(bingbot|Bolt|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Chrome|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|iTunes|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin|qutebrowser|Otter|QupZilla|MailBar|kmail2|YahooMobileMail|ExchangeWebServices|ExchangeServicesClient|Microsoft-CryptoAPI)/(\d+)\.(\d+)\.?(\d+)?'
+  - regex: '(bingbot|Bolt|AdobeAIR|Jasmine|IceCat|Skyfire|Midori|Maxthon|Lynx|Arora|IBrowse|Dillo|Camino|Shiira|Fennec|Phoenix|Flock|Netscape|Lunascape|Epiphany|WebPilot|Opera Mini|Opera|NetFront|Netfront|Konqueror|Googlebot|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|iCab|iTunes|MacAppStore|NetNewsWire|Space Bison|Stainless|Orca|Dolfin|BOLT|Minimo|Tizen Browser|Polaris|Abrowser|Planetweb|ICE Browser|mDolphin|qutebrowser|Otter|QupZilla|MailBar|kmail2|YahooMobileMail|ExchangeWebServices|ExchangeServicesClient)/(\d+)\.(\d+)(?:\.(\d+))?'
 
   # Chrome/Chromium/major_version.minor_version
-  - regex: '(Chromium|Chrome)/(\d+)\.(\d+)'
+  - regex: '(Chromium|Chrome)/(\d+)\.(\d+)(?:\.(\d+))?'
 
   ##########
   # IE Mobile needs to happen before Android to catch cases such as:
@@ -360,6 +365,9 @@ user_agent_parsers:
   # IE Mobile
   - regex: '(IEMobile)[ /](\d+)\.(\d+)'
     family_replacement: 'IE Mobile'
+
+  # Baca Berita App News Reader
+  - regex: '(BacaBerita App)\/(\d+)\.(\d+)\.(\d+)'
 
   # Browser major_version.minor_version.beta_version (space instead of slash)
   - regex: '(iRider|Crazy Browser|SkipStone|iCab|Lunascape|Sleipnir|Maemo Browser) (\d+)\.(\d+)\.(\d+)'
@@ -553,10 +561,18 @@ user_agent_parsers:
   - regex: '(python-requests)/(\d+)\.(\d+)'
     family_replacement: 'Python Requests'
 
+  # headless user-agents
+  - regex: '\b(Windows-Update-Agent|Microsoft-CryptoAPI|SophosUpdateManager|SophosAgent|Debian APT-HTTP|Ubuntu APT-HTTP|libcurl-agent|libwww-perl|urlgrabber|curl|Wget|OpenBSD ftp|jupdate)(?:[ /](\d+)(?:\.(\d+)(?:\.(\d+))?)?)?'
+
   - regex: '(Java)[/ ]{0,1}\d+\.(\d+)\.(\d+)[_-]*([a-zA-Z0-9]+)*'
 
   # Roku Digital-Video-Players https://www.roku.com/
   - regex: '^(Roku)/DVP-(\d+)\.(\d+)'
+
+  # Kurio App News Reader https://kurio.co.id/
+  - regex: '(Kurio)\/(\d+)\.(\d+)\.(\d+)'
+    family_replacement: 'Kurio App'
+
 
 os_parsers:
   ##########
@@ -655,7 +671,7 @@ os_parsers:
   # UCWEB
   - regex: '^UCWEB.*; (Adr) (\d+)\.(\d+)(?:[.\-]([a-z0-9]+))?;'
     os_replacement: 'Android'
-  - regex: '^UCWEB.*; (iPad OS|iPh OS) (\d+)_(\d+)(?:_(\d+))?;'
+  - regex: '^UCWEB.*; (iPad|iPh|iPd) OS (\d+)_(\d+)(?:_(\d+))?;'
     os_replacement: 'iOS'
   - regex: '^UCWEB.*; (wds) (\d+)\.(\d+)(?:\.(\d+))?;'
     os_replacement: 'Windows Phone'
@@ -875,8 +891,9 @@ os_parsers:
     os_v1_replacement: '10'
     os_v2_replacement: '0'
   # iOS Apps
-  - regex: '\b(iOS[ /]|iPhone(?:/| v|[ _]OS[/,]|; | OS : |\d,\d/|\d,\d; )|iPad/)(\d{1,2})[_\.](\d{1,2})(?:[_\.](\d+))?'
+  - regex: '\b(iOS[ /]|iOS; |iPhone(?:/| v|[ _]OS[/,]|; | OS : |\d,\d/|\d,\d; )|iPad/)(\d{1,2})[_\.](\d{1,2})(?:[_\.](\d+))?'
     os_replacement: 'iOS'
+  - regex: '\((iOS);'
 
   ##########
   # Apple TV
@@ -4628,6 +4645,11 @@ device_parsers:
   ##########
   # Samsung
   ##########
+  # Samsung Smart-TV
+  - regex: '(SMART-TV); .* Tizen '
+    device_replacement: 'Samsung $1'
+    brand_replacement: 'Samsung'
+    model_replacement: '$1'
   # Samsung Symbian Devices
   - regex: 'SymbianOS/9\.\d.* Samsung[/\-]([A-Za-z0-9 \-]+)'
     device_replacement: 'Samsung $1'

--- a/test/ua_parser/parsers/device_test.exs
+++ b/test/ua_parser/parsers/device_test.exs
@@ -10,6 +10,6 @@ defmodule UAParser.Parsers.DeviceTest do
     {_, _, [pattern|_]} = Storage.list
 
     result = Parser.parse({pattern, ["iPod;", "iPod"]})
-    assert %Device{family: "Spider"} = result
+    assert %Device{family: "Spider", brand: "Spider", model: "Smartphone"} == result
   end
 end

--- a/test/ua_parser/parsers/operating_system_parser_test.exs
+++ b/test/ua_parser/parsers/operating_system_parser_test.exs
@@ -5,8 +5,8 @@ defmodule UAParser.Parsers.OperatingSystemTest do
   alias UAParser.{OperatingSystem, Version}
 
   @user_string "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; en-us) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/2.0"
-  @pattern [regex: ~r/((?:Mac ?|; )OS X)[\s\/](?:(\d+)[_.](\d+)(?:[_.](\d+))?|Mach-O)/,
-            os_replacement: "Mac OS X"]
+  @pattern %{regex: ~r/((?:Mac ?|; )OS X)[\s\/](?:(\d+)[_.](\d+)(?:[_.](\d+))?|Mach-O)/,
+            os_replacement: "Mac OS X"}
   @match ["Mac OS X 10_5_7", "Mac OS X", "10", "5", "7"]
 
   test "parses operating system information" do

--- a/test/ua_parser/parsers/user_agent_test.exs
+++ b/test/ua_parser/parsers/user_agent_test.exs
@@ -5,7 +5,7 @@ defmodule UAParser.Parsers.UATest do
   alias UAParser.{UA, Version}
 
   @user_string "Mozilla/5.0 (Windows; U; en-US) AppleWebKit/531.9 (KHTML, like Gecko) AdobeAIR/2.5.1"
-  @pattern [regex: ~r/\b(MobileIron|Crosswalk|AdobeAIR|FireWeb|Jasmine|ANTGalio|Midori|Fresco|Lobo|PaleMoon|Maxthon|Lynx|OmniWeb|Dillo|Camino|Demeter|Fluid|Fennec|Epiphany|Shiira|Sunrise|Spotify|Flock|Netscape|Lunascape|WebPilot|NetFront|Netfront|Konqueror|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|Opera Mini|iCab|NetNewsWire|ThunderBrowse|Iris|UP\.Browser|Bunjalloo|Google Earth|Raven for Mac|Openwave|MacOutlook)\/(\d+)\.(\d+)\.(\d+)/]
+  @pattern %{regex: ~r/\b(MobileIron|Crosswalk|AdobeAIR|FireWeb|Jasmine|ANTGalio|Midori|Fresco|Lobo|PaleMoon|Maxthon|Lynx|OmniWeb|Dillo|Camino|Demeter|Fluid|Fennec|Epiphany|Shiira|Sunrise|Spotify|Flock|Netscape|Lunascape|WebPilot|NetFront|Netfront|Konqueror|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|Opera Mini|iCab|NetNewsWire|ThunderBrowse|Iris|UP\.Browser|Bunjalloo|Google Earth|Raven for Mac|Openwave|MacOutlook)\/(\d+)\.(\d+)\.(\d+)/}
   @match ["AdobeAIR/2.5.1", "AdobeAIR", "2", "5", "1"]
 
   test "parses user agent information" do

--- a/test/ua_parser/parsers/version_test.exs
+++ b/test/ua_parser/parsers/version_test.exs
@@ -5,8 +5,8 @@ defmodule UAParser.Parsers.VersionTest do
   alias UAParser.Version
 
   @user_string "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; en-us) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/2.0"
-  @pattern [regex: ~r/((?:Mac ?|; )OS X)[\s\/](?:(\d+)[_.](\d+)(?:[_.](\d+))?|Mach-O)/,
-            os_replacement: "Mac OS X"]
+  @pattern %{regex: ~r/((?:Mac ?|; )OS X)[\s\/](?:(\d+)[_.](\d+)(?:[_.](\d+))?|Mach-O)/,
+            os_replacement: "Mac OS X"}
   @match ["Mac OS X", "10", "5", "7"]
   @replacement_keys [:not_used, :not_used, :not_used, :not_used]
 

--- a/test/ua_parser/processor_test.exs
+++ b/test/ua_parser/processor_test.exs
@@ -8,13 +8,14 @@ defmodule UAParser.ProcessorTest do
 
     assert is_tuple(result)
     assert tuple_size(result) == 3
-    assert [[{:regex, pattern}]] = elem(result, 0)
+    assert [%{regex: pattern}] = elem(result, 0)
     assert Regex.regex?(pattern)
   end
 
   def test_data do
-    File.cwd!
+    {:ok, data} = File.cwd!
     |> Path.join("test/fixtures/patterns.yml")
-    |> :yamerl_constr.file
+    |> Yomel.decode_file
+    data
   end
 end


### PR DESCRIPTION
Happy to keep this as fork of this if the changes are too drastic.

1. Using a GenServer is an unnecessary bottleneck especially when you are able to load the yaml at compile time - and you aren't doing any work inside the worker process besides holding state.  Although another option would be to use ets to store the data. I can dig in deeper but its harder to configure which yaml file you actually use. Honestly didn't look that far into Yomel the yaml parser being used - but essentially it made sense as it didn't start an application. You would actually start to see the mailbox fill up on the Storage GenServer at a reasonable scale

2. Maps have slightly better performance than keyword lists. Granted the ones you used are super small - so not really a huge difference.

3. Added model and brand to device parsing.