### PR TITLE
Fix error when parsing certain user agent strings

### DIFF
--- a/lib/ua_parser/parser.ex
+++ b/lib/ua_parser/parser.ex
@@ -11,9 +11,9 @@ defmodule UAParser.Parser do
   def parse({ua_patterns, os_patterns, device_patterns}, user_agent) do
     user_agent
     |> sanitize
-    |> parse_os(os_patterns)
-    |> parse_device(device_patterns)
     |> parse_user_agent(ua_patterns)
+    |> parse_device(device_patterns)
+    |> parse_os(os_patterns)
   end
 
   defp find_and_parse(patterns, user_agent, module) do
@@ -37,15 +37,15 @@ defmodule UAParser.Parser do
     {user_agent, Map.put(acc, :device, device)}
   end
 
-  defp parse_os(user_agent, patterns) do
+  defp parse_os({user_agent, acc}, patterns) do
     os = find_and_parse(patterns, user_agent, OperatingSystem)
-    {user_agent, %{os: os}}
+    Map.put(acc, :os, os)
   end
 
-  defp parse_user_agent({user_agent, acc}, patterns) do
-    patterns
-    |> find_and_parse(user_agent, UA)
-    |> Map.merge(acc)
+  defp parse_user_agent(user_agent, patterns) do
+    ua = find_and_parse(patterns, user_agent, UA)
+
+    {user_agent, ua}
   end
 
   defp sanitize(user_agent), do: String.trim(user_agent)

--- a/lib/ua_parser/parsers/base.ex
+++ b/lib/ua_parser/parsers/base.ex
@@ -28,6 +28,10 @@ defmodule UAParser.Parsers.Base do
   def replace(nil, position, match), do: Enum.at(match, position)
   def replace(string, position, match) do
     val = Enum.at(match, position)
-    String.replace(string, "$#{position}", val)
+    if val do
+      String.replace(string, "$#{position}", val)
+    else
+      string
+    end
   end
 end

--- a/lib/ua_parser/parsers/user_agent.ex
+++ b/lib/ua_parser/parsers/user_agent.ex
@@ -9,8 +9,8 @@ defmodule UAParser.Parsers.UA do
 
   replacement_parser struct: UA,
                        keys: [:family_replacement,
-                              :os_replacement,
-                              :os_replacement,
-                              :os_replacement,
-                              :os_replacement]
+                              :v1_replacement,
+                              :v2_replacement,
+                              :v3_replacement,
+                              :v4_replacement]
 end

--- a/lib/ua_parser/parsers/version.ex
+++ b/lib/ua_parser/parsers/version.ex
@@ -24,6 +24,7 @@ defmodule UAParser.Parsers.Version do
     |> replace(index + 1, match)
   end
 
+  defp version([major]), do: %Version{major: major}
   defp version([major, minor, patch, patch_minor]),
     do: %Version{major: major, minor: minor, patch: patch, patch_minor: patch_minor}
 end

--- a/test/ua_parser/parsers/device_test.exs
+++ b/test/ua_parser/parsers/device_test.exs
@@ -4,8 +4,6 @@ defmodule UAParser.Parsers.DeviceTest do
   alias UAParser.Parsers.Device, as: Parser
   alias UAParser.{Device, Storage}
 
-  @user_string "Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5"
-
   test "parses device information" do
     {_, _, [pattern|_]} = Storage.list
 

--- a/test/ua_parser/parsers/operating_system_parser_test.exs
+++ b/test/ua_parser/parsers/operating_system_parser_test.exs
@@ -4,7 +4,6 @@ defmodule UAParser.Parsers.OperatingSystemTest do
   alias UAParser.Parsers.OperatingSystem, as: Parser
   alias UAParser.{OperatingSystem, Version}
 
-  @user_string "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; en-us) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/2.0"
   @pattern [regex: ~r/((?:Mac ?|; )OS X)[\s\/](?:(\d+)[_.](\d+)(?:[_.](\d+))?|Mach-O)/,
             os_replacement: "Mac OS X"]
   @match ["Mac OS X 10_5_7", "Mac OS X", "10", "5", "7"]

--- a/test/ua_parser/parsers/user_agent_test.exs
+++ b/test/ua_parser/parsers/user_agent_test.exs
@@ -4,7 +4,6 @@ defmodule UAParser.Parsers.UATest do
   alias UAParser.Parsers.UA, as: Parser
   alias UAParser.{UA, Version}
 
-  @user_string "Mozilla/5.0 (Windows; U; en-US) AppleWebKit/531.9 (KHTML, like Gecko) AdobeAIR/2.5.1"
   @pattern [regex: ~r/\b(MobileIron|Crosswalk|AdobeAIR|FireWeb|Jasmine|ANTGalio|Midori|Fresco|Lobo|PaleMoon|Maxthon|Lynx|OmniWeb|Dillo|Camino|Demeter|Fluid|Fennec|Epiphany|Shiira|Sunrise|Spotify|Flock|Netscape|Lunascape|WebPilot|NetFront|Netfront|Konqueror|SeaMonkey|Kazehakase|Vienna|Iceape|Iceweasel|IceWeasel|Iron|K-Meleon|Sleipnir|Galeon|GranParadiso|Opera Mini|iCab|NetNewsWire|ThunderBrowse|Iris|UP\.Browser|Bunjalloo|Google Earth|Raven for Mac|Openwave|MacOutlook)\/(\d+)\.(\d+)\.(\d+)/]
   @match ["AdobeAIR/2.5.1", "AdobeAIR", "2", "5", "1"]
 

--- a/test/ua_parser/parsers/version_test.exs
+++ b/test/ua_parser/parsers/version_test.exs
@@ -4,7 +4,6 @@ defmodule UAParser.Parsers.VersionTest do
   alias UAParser.Parsers.Version, as: Parser
   alias UAParser.Version
 
-  @user_string "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; en-us) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/2.0"
   @pattern [regex: ~r/((?:Mac ?|; )OS X)[\s\/](?:(\d+)[_.](\d+)(?:[_.](\d+))?|Mach-O)/,
             os_replacement: "Mac OS X"]
   @match ["Mac OS X", "10", "5", "7"]

--- a/test/ua_parser/processor_test.exs
+++ b/test/ua_parser/processor_test.exs
@@ -4,7 +4,7 @@ defmodule UAParser.ProcessorTest do
   alias UAParser.Processor
 
   test "converts yaml document into data structure" do
-    result = Processor.process(test_data)
+    result = Processor.process(test_data())
 
     assert is_tuple(result)
     assert tuple_size(result) == 3


### PR DESCRIPTION
A bug was found with two UA strings:

+ "Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)"
+ "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; Microsoft Outlook 15.0.4711; ms-office; MSOffice 15)"

Upon digging in I found a bug with how we were parsing versions and the order in which we did our parsing, this PR corrects that.