### PR TITLE
Update replacement_parser/1

### DIFF
--- a/lib/ua_parser/parsers/base.ex
+++ b/lib/ua_parser/parsers/base.ex
@@ -18,7 +18,7 @@ defmodule UAParser.Parsers.Base do
           |> Keyword.get(unquote(family_key))
           |> UAParser.Parsers.Base.replace(1, match)
 
-        match = Enum.slice(match, 1, 4)
+        match = Enum.slice(match, 1, 5)
         version = UAParser.Parsers.Version.parse({group, match}, unquote(replacements))
 
         struct(unquote(mod), %{family: family, version: version})


### PR DESCRIPTION
In the `replacement_parser` macro, the list `match` may include a value for a browser's minor patch version - however, this value was being trimmed off by

`match = Enum.slice(match, 1, 4)`

which might receive a list like

`["Chrome/66.0.3359.181", "Chrome", "66", "0", "3359", "181"]`

and return

`["Chrome", "66", "0", "3359"]`

By expanding the range of the `slice` to `5`, that minor patch version will be captured, if it's present.