### PR TITLE
Allow custom patterns

### DIFF
--- a/lib/ua_parser.ex
+++ b/lib/ua_parser.ex
@@ -19,9 +19,8 @@ defmodule UAParser do
     iex> to_string(ua.device)
     "Other"
   """
-  def parse(ua), do: parse(ua, default_pattern)
+  def parse(ua), do: parse(ua, default_pattern())
   def parse(ua, pattern), do: Parser.parse(pattern, ua)
-
 
   defp default_pattern, do: Storage.list()
 end

--- a/lib/ua_parser.ex
+++ b/lib/ua_parser.ex
@@ -19,7 +19,9 @@ defmodule UAParser do
     iex> to_string(ua.device)
     "Other"
   """
-  def parse(ua), do: Parser.parse(pattern(), ua)
+  def parse(ua), do: parse(ua, default_pattern)
+  def parse(ua, pattern), do: Parser.parse(pattern, ua)
 
-  defp pattern, do: Storage.list()
+
+  defp default_pattern, do: Storage.list()
 end

--- a/test/ua_parser_test.exs
+++ b/test/ua_parser_test.exs
@@ -1,4 +1,30 @@
 defmodule UAParserTest do
   use ExUnit.Case
   doctest UAParser
+
+  @user_agent "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; en-us) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/2.0"
+
+  test "parse user_agent using default patterns" do
+    ua = UAParser.parse(@user_agent)
+    assert to_string(ua) == "Skyfire 2.0"
+    assert to_string(ua.os) == "Mac OS X 10.5.7"
+    assert to_string(ua.device) == "Other"
+  end
+
+  test "parse user_agent using custom patterns" do
+    custom_patterns = {
+      [
+        [
+          regex: ~r/(Skyfire)\/(\d+)\.(\d+)(?:\.(\d+))?/,
+          family_replacement: "Testing Pattern $1"
+        ]
+      ],
+      [],
+      []
+    }
+
+    ua = UAParser.parse(@user_agent, custom_patterns)
+    assert ua.family == "Testing Pattern Skyfire"
+    assert to_string(ua.version) == "2.0"
+  end
 end


### PR DESCRIPTION
My PR make possible users use the own patterns.

For example, I'm using a [uap-core](https://github.com/ua-parser/uap-core) version

Code example: 
```elixir
# using default patterns
ua = UAParser.parse(request["http_user_agent"])

# using custom patterns
patterns =
    Path.join([File.cwd!, "vendor", "uap-core", "regexes.yaml"])
    |> :yamerl_constr.file([])
    |> UAParser.Processor.process()
 
ua = UAParser.parse(request["http_user_agent"], patterns)
```