### PR TITLE
Indents examples correctly and fixes headers

### DIFF
--- a/lib/ua_parser.ex
+++ b/lib/ua_parser.ex
@@ -8,16 +8,16 @@ defmodule UAParser do
   @doc """
   Parse a user-agent string into structs
 
-  # Examples
+  ## Examples
 
-    iex> agent_string = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; en-us) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/2.0"
-    iex> ua = UAParser.parse(agent_string)
-    iex> to_string(ua)
-    "Skyfire 2.0"
-    iex> to_string(ua.os)
-    "Mac OS X 10.5.7"
-    iex> to_string(ua.device)
-    "Other"
+      iex> agent_string = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; en-us) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/2.0"
+      iex> ua = UAParser.parse(agent_string)
+      iex> to_string(ua)
+      "Skyfire 2.0"
+      iex> to_string(ua.os)
+      "Mac OS X 10.5.7"
+      iex> to_string(ua.device)
+      "Other"
   """
   def parse(ua), do: parse(ua, default_pattern())
   def parse(ua, pattern), do: Parser.parse(pattern, ua)

--- a/lib/ua_parser/device.ex
+++ b/lib/ua_parser/device.ex
@@ -4,15 +4,15 @@ defmodule UAParser.Device do
   """
 
   @doc """
-  # Examples
+  ## Examples
 
-    iex> device = %UAParser.Device{family: "iPhone"}
-    iex> to_string(device)
-    "iPhone"
+      iex> device = %UAParser.Device{family: "iPhone"}
+      iex> to_string(device)
+      "iPhone"
 
-    iex> device = %UAParser.Device{}
-    iex> to_string(device)
-    "Other"
+      iex> device = %UAParser.Device{}
+      iex> to_string(device)
+      "Other"
   """
   defstruct [:brand, :family, :model]
 end

--- a/lib/ua_parser/operating_system.ex
+++ b/lib/ua_parser/operating_system.ex
@@ -4,16 +4,16 @@ defmodule UAParser.OperatingSystem do
   """
 
   @doc """
-  # Examples
+  ## Examples
 
-    iex> version = %UAParser.Version{major: "1", minor: "2"}
-    iex> os = %UAParser.OperatingSystem{family: "macOS", version: version}
-    iex> to_string(os)
-    "macOS 1.2"
+      iex> version = %UAParser.Version{major: "1", minor: "2"}
+      iex> os = %UAParser.OperatingSystem{family: "macOS", version: version}
+      iex> to_string(os)
+      "macOS 1.2"
 
-    iex> os = %UAParser.OperatingSystem{family: "macOS"}
-    iex> to_string(os)
-    "macOS"
+      iex> os = %UAParser.OperatingSystem{family: "macOS"}
+      iex> to_string(os)
+      "macOS"
   """
   defstruct [:family, :version]
 end

--- a/lib/ua_parser/user_agent.ex
+++ b/lib/ua_parser/user_agent.ex
@@ -6,20 +6,20 @@ defmodule UAParser.UA do
   @doc """
   Display the UA as a string
 
-  # Examples
+  ## Examples
 
-    iex> version = %UAParser.Version{major: "1", minor: "2", patch: "3", patch_minor: "4"}
-    iex> agent = %UAParser.UA{family: "Family", version: version}
-    iex> to_string(agent)
-    "Family 1.2.3.4"
+      iex> version = %UAParser.Version{major: "1", minor: "2", patch: "3", patch_minor: "4"}
+      iex> agent = %UAParser.UA{family: "Family", version: version}
+      iex> to_string(agent)
+      "Family 1.2.3.4"
 
-    iex> agent = %UAParser.UA{family: "Family"}
-    iex> to_string(agent)
-    "Family"
+      iex> agent = %UAParser.UA{family: "Family"}
+      iex> to_string(agent)
+      "Family"
 
-    iex> agent = %UAParser.UA{}
-    iex> to_string(agent)
-    "Other"
+      iex> agent = %UAParser.UA{}
+      iex> to_string(agent)
+      "Other"
   """
 
   defstruct [:device, :family, :os, :version]

--- a/lib/ua_parser/version.ex
+++ b/lib/ua_parser/version.ex
@@ -4,23 +4,23 @@ defmodule UAParser.Version do
   """
 
   @doc """
-  # Examples
+  ## Examples
 
-    iex> version = %UAParser.Version{major: "1", minor: "2", patch: "3", patch_minor: "4"}
-    iex> to_string(version)
-    "1.2.3.4"
+      iex> version = %UAParser.Version{major: "1", minor: "2", patch: "3", patch_minor: "4"}
+      iex> to_string(version)
+      "1.2.3.4"
 
-    iex> version = %UAParser.Version{major: "1", minor: "2", patch: "3"}
-    iex> to_string(version)
-    "1.2.3"
+      iex> version = %UAParser.Version{major: "1", minor: "2", patch: "3"}
+      iex> to_string(version)
+      "1.2.3"
 
-    iex> version = %UAParser.Version{major: "1", minor: "2"}
-    iex> to_string(version)
-    "1.2"
+      iex> version = %UAParser.Version{major: "1", minor: "2"}
+      iex> to_string(version)
+      "1.2"
 
-    iex> version = %UAParser.Version{major: "1"}
-    iex> to_string(version)
-    "1"
+      iex> version = %UAParser.Version{major: "1"}
+      iex> to_string(version)
+      "1"
   """
   defstruct [:major, :minor, :patch, :patch_minor]
 end


### PR DESCRIPTION
This ensures the code samples presented on hexdocs.pm are readable and properly syntax highlighted.

<hr />

**Before...**

<img width="772" alt="Screenshot 2019-04-09 at 13 00 44" src="https://user-images.githubusercontent.com/175/55798723-949fc080-5ac7-11e9-8f14-4012f3b6f73c.png">

**...and after**

<img width="851" alt="Screenshot 2019-04-09 at 13 01 01" src="https://user-images.githubusercontent.com/175/55798730-99fd0b00-5ac7-11e9-9724-b7c3016756e9.png">
