### PR TITLE
chore: replace stordco/actions-elixir/setup with erlef/setup-beam

### DIFF
--- a/.github/workflows/common-config.yaml
+++ b/.github/workflows/common-config.yaml
@@ -35,7 +35,7 @@ jobs:
           node-version: 20
 
       - name: Setup Elixir
-        uses: stordco/actions-elixir/setup@v1
+        uses: erlef/setup-beam@v1
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           elixir-version: "1.16"


### PR DESCRIPTION
## Summary
- Replaces `stordco/actions-elixir/setup@v1` with `erlef/setup-beam@v1` in the common-config workflow

This aligns with the changes made in [beam-community/common-config#76](https://github.com/beam-community/common-config/pull/76).

## Test plan
- [ ] Verify the common-config workflow runs successfully with the new action