### PR TITLE
fix(ci): update common-config workflow to use beam-community/actions-sync

### DIFF
--- a/.github/workflows/common-config.yaml
+++ b/.github/workflows/common-config.yaml
@@ -12,7 +12,7 @@ on:
     types:
       - common-config
   schedule:
-    - cron: "8 12 8 * *"
+    - cron: "0 0 1 * *"
   workflow_dispatch: {}
 
 concurrency:
@@ -38,11 +38,11 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          elixir-version: "1.16"
-          otp-version: "26.0"
+          elixir-version: "1.19"
+          otp-version: "27.0"
 
       - name: Sync
-        uses: stordco/actions-sync@v1
+        uses: beam-community/actions-sync@v1
         with:
           commit-message: "chore: sync files with beam-community/common-config"
           pr-enabled: true
@@ -52,3 +52,4 @@ jobs:
           sync-auth: doomspork:${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           sync-tree: latest
           sync-repository: github.com/beam-community/common-config.git
+          config-file: .github/common-config.yaml


### PR DESCRIPTION
## Summary

- Replaces `stordco/actions-sync@v1` with `beam-community/actions-sync@v1` — the action moved orgs, causing the \"Unable to resolve action\" failure
- Bumps Elixir `1.16` → `1.19` and OTP `26.0` → `27.0` to match other beam-community repos
- Updates cron schedule from `"8 12 8 * *"` to `"0 0 1 * *"` (monthly on the 1st at midnight)
- Adds `config-file: .github/common-config.yaml` input, a newer feature of `actions-sync` that lets the repo declare which files to sync

### Test Steps

1. Merge this PR
2. Trigger the **Common Config** workflow manually via Actions → Common Config → Run workflow
3. Confirm the Sync step completes successfully (no \"Unable to resolve action\" error)

### Checklist
- [x] No code changes — CI config only
- [ ] Documentation updated (if applicable)